### PR TITLE
libheif 1.19.5 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/84cc126
+  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/b608b1e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/b608b1e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
 upload_channels:
   - sfe1ed40
 
+channels:
+  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/84cc126

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,8 @@ cmake -G "Ninja" ^
   -DWITH_EXAMPLES=OFF ^
   -DWITH_SvtEnc=OFF ^
   -DWITH_RAV1E=OFF ^
+  -DWITH_DAV1D=ON ^
+  -DWITH_DAV1D_PLUGIN=OFF ^
   -DBUILD_TESTING=OFF ^
   ..
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,8 @@ cmake ${CMAKE_ARGS} -G "Ninja" \
   -DWITH_EXAMPLES=OFF \
   -DWITH_SvtEnc=OFF \
   -DWITH_RAV1E=OFF \
+  -DWITH_DAV1D=ON \
+  -DWITH_DAV1D_PLUGIN=OFF \
   ..
 
 ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,7 @@ about:
   license_family: LGPL
   license_file: COPYING
   dev_url: https://github.com/strukturag/libheif
+  doc_url: https://github.com/strukturag/libheif
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,20 +13,19 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/strukturag/libheif/releases/download/v{{ version }}/libheif-{{ version }}.tar.gz
+  url: https://github.com/strukturag/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf
 
 build:
   number: {{ build }}
   string: {{ license_family }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
-  run_exports:
-    - {{ pin_subpackage('libheif', max_pin='x.x') }}
 
 requirements:
   build:
+    - python  # otherwise it will fail on conda build
     - gnuconfig  # [unix]
     - {{ compiler('cxx') }}
-    - {{ stdlib('c') }}
+    # - {{ stdlib('c') }}  # issues an error of 'c_osx-arm64 not exists'
     - cmake
     - ninja
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ requirements:
     - dav1d
     - aom
     - x265  # [license_family == 'gpl']
+  run:
+    - x265  # [license_family == 'gpl']
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - gnuconfig  # [unix]
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
+    - ninja-base
   host:
     - libde265
     - dav1d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,9 @@ build:
   string: {{ license_family }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
 
 requirements:
-  build:
+  host:
     - python  # otherwise it will fail on conda build
+  build:
     - gnuconfig  # [unix]
     - {{ compiler('cxx') }}
     # - {{ stdlib('c') }}  # issues an error of 'c_osx-arm64 not exists'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,6 @@ build:
   string: {{ license_family }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
 
 requirements:
-  host:
-    - python  # otherwise it will fail on conda build
   build:
     - python  # otherwise it will fail on conda build
     - gnuconfig  # [unix]
@@ -31,6 +29,7 @@ requirements:
     - cmake
     - ninja
   host:
+    - python  # otherwise it will fail on conda build
     - libde265
     - libavif
     # - svt-av1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,11 @@ requirements:
     # - rav1e
     - dav1d
     - aom
-    - x265  # [license_family == 'gpl']
+    # - x265  # [license_family == 'gpl']
+    - x265
   run:
-    - x265  # [license_family == 'gpl']
+    # - x265  # [license_family == 'gpl']
+    - x265
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   host:
     - python  # otherwise it will fail on conda build
   build:
+    - python  # otherwise it will fail on conda build
     - gnuconfig  # [unix]
     - {{ compiler('cxx') }}
     # - {{ stdlib('c') }}  # issues an error of 'c_osx-arm64 not exists'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf
 
 build:
-  # x265 not available for s390x
-  skip: True  # [s390x]
+  # x265 not available for s390x and win
+  skip: True  # [s390x or win]
   number: 0
   run_exports:
     - {{ pin_subpackage('libheif', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   skip: True  # [s390x]
   number: 0
   run_exports:
-    - {{ pin_subpackage('libheif', max_pin='x.x.x') }}
+    - {{ pin_subpackage('libheif', max_pin='x.x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,10 @@ requirements:
     - cmake
     - ninja-base
   host:
-    - libde265
-    - dav1d
-    - aom
-    - x265
+    - libde265 1.0.15
+    - dav1d 1.2.1
+    - aom 3.6
+    - x265 3.5
   run:
     - libde265
     - x265

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   sha256: d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf
 
 build:
+  # x265 not available for s390x
+  skip: True  # [s390x]
   number: 0
   run_exports:
     - {{ pin_subpackage('libheif', max_pin='x.x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,5 @@
-{% set build = 0 %}
 {% set name = "libheif" %}
 {% set version = "1.19.5" %}
-# ensure license_family is defined to appease bot
-{% set license_family = license_family or 'notset' %}
-
-{%- if license_family == 'gpl' %}
-{%- set build = build + 100 %}
-{%- endif %}
 
 package:
   name: {{ name|lower }}
@@ -17,29 +10,23 @@ source:
   sha256: d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf
 
 build:
-  number: {{ build }}
-  string: {{ license_family }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('libheif', max_pin='x.x.x') }}
 
 requirements:
   build:
-    - python  # otherwise it will fail on conda build
     - gnuconfig  # [unix]
     - {{ compiler('cxx') }}
-    # - {{ stdlib('c') }}  # issues an error of 'c_osx-arm64 not exists'
     - cmake
     - ninja
   host:
-    - python  # otherwise it will fail on conda build
     - libde265
-    - libavif
-    # - svt-av1
-    # - rav1e
     - dav1d
     - aom
-    # - x265  # [license_family == 'gpl']
     - x265
   run:
-    # - x265  # [license_family == 'gpl']
+    - libde265
     - x265
 
 test:


### PR DESCRIPTION
libheif 1.19.5 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6336](https://anaconda.atlassian.net/browse/PKG-6336) 
- [Upstream repository](https://github.com/strukturag/libheif)

### Explanation of changes:

- Updated to 1.19.5
- **NOTE: we are skipping c++ tests here, as the package is tested downstream in `pi-heif`. In future it might be beneficial to build and run c++ tests too.**


[PKG-6336]: https://anaconda.atlassian.net/browse/PKG-6336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ